### PR TITLE
First launch fix (#132)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,12 +5,14 @@ EXPOSE 80
 FROM microsoft/dotnet:2.1-sdk AS build
 WORKDIR /src
 ENV IS_DOCKER true
-COPY . .
-RUN dotnet restore src/BaGet
-RUN dotnet build src/BaGet -c Release -o /app
+COPY /src .
+RUN dotnet restore BaGet
+RUN dotnet build BaGet -c Release -o /app
 
 FROM build AS publish
-RUN dotnet publish src/BaGet -c Release -o /app
+RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
+RUN apt-get install -y nodejs
+RUN dotnet publish BaGet -c Release -o /app
 
 FROM base AS final
 WORKDIR /app

--- a/src/BaGet/BaGet.csproj
+++ b/src/BaGet/BaGet.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
 
-    <SpaRoot>..\Baget.UI\</SpaRoot>
+    <SpaRoot>..\BaGet.UI\</SpaRoot>
     <DefaultItemExcludes>$(DefaultItemExcludes);$(SpaRoot)node_modules\**</DefaultItemExcludes>
   </PropertyGroup>
 

--- a/src/BaGet/Startup.cs
+++ b/src/BaGet/Startup.cs
@@ -28,7 +28,7 @@ namespace BaGet
             // In production, the UI files will be served from this directory
             services.AddSpaStaticFiles(configuration =>
             {
-                configuration.RootPath = "Baget.UI/build";
+                configuration.RootPath = "BaGet.UI/build";
             });
         }
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -16,7 +16,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="$(IS_DOCKER) == ''">
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All"/>
   </ItemGroup>
 


### PR DESCRIPTION
Fixes build and run nuget server on docker:

    - changed Baget.UI folder references to correct ones (BaGet.UI) because microsoft dotnet images are based on debian linux and is case sensitive for the forlder names
    - ignored SouceLink msbuild targets for docker builds because you do not need debugging experience inside container (and it build failed because of these targets)
    - updated publish stage to install nodejs inside dotnet sdk image because it do not include nodjs and dotnet publish command causes BaGet.UI npm commads to run

<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Read the contributing guide: https://github.com/loic-sharma/BaGet/blob/master/CONTRIBUTING.md.
- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Once approved, please squash your commits to avoid polluting the commit history.
-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

### Closes Issue(s)

<!-- List here all the issues closed by this pull request. -->

### Motivation

<!-- What inspired you to submit this pull request? -->

### Additional Notes

<!-- Anything else we should know when reviewing? -->